### PR TITLE
Change add tasks methods

### DIFF
--- a/src/main/java/Dawn/Dawn.java
+++ b/src/main/java/Dawn/Dawn.java
@@ -9,7 +9,7 @@ public class Dawn {
     public Dawn() {
         this.storage = new Storage("data/Dawn.txt");
         try {
-            this.taskList = new TaskList(storage.load());
+            this.taskList = storage.load(new TaskList());
         } catch (DawnException ex) {
             this.taskList = new TaskList();
         }

--- a/src/main/java/Dawn/Storage.java
+++ b/src/main/java/Dawn/Storage.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Scanner;
 
 import static Dawn.TaskList.getTask;
@@ -25,7 +26,6 @@ public class Storage {
         File file = new File(dirPath);
         file.mkdir();
 
-        this.savedTasks = new ArrayList<>();
         this.filePath = filePath;
     }
 
@@ -35,57 +35,27 @@ public class Storage {
      * @return a list of tasks
      * @throws DawnException
      */
-    public ArrayList<Task> load() throws DawnException {
+    public TaskList load(TaskList taskList) throws DawnException {
+        //todo change to use one addtask method
         File f;
         try {
             f = new File(this.filePath);
             // handles case file-already-exists, and
             // case file-does-not-exist-yet by creating a new text file
-            // returns true if the file is created and false if the file already exists
             if (!f.createNewFile()) {
                 Scanner s = new Scanner(f);
                 while (s.hasNextLine()) {
-                    String[] taskContent = s.nextLine().split(" \\| ");
-                    TaskType type = TaskType.valueOf(taskContent[0]);
-                    Task task = generateSavedTask(taskContent, type);
-                    savedTasks.add(task);
+                    String[] taskContent = s.nextLine().split(" ");
+                    String detail = String.join(" ",
+                            Arrays.copyOfRange(taskContent, 2, taskContent.length));
+                    TaskList.addTask(taskContent[0], detail, taskContent[1]);
                 }
-                clearSavedTask(this.filePath); // clear the previously saved tasks
+                clearSavedTask(this.filePath);
             }
-            return this.savedTasks;
+            return taskList;
         } catch (IOException e) {
             throw new DawnException("Unable to load previously saved tasks: " + e.getMessage());
         }
-    }
-
-    enum TaskType {
-        T,
-        D,
-        E
-    }
-
-    protected Task generateSavedTask(String[] taskContent, TaskType type) throws DawnException {
-        boolean isDone = taskContent[1].equals("1"); // checks if the status of the task is 0 or 1
-        Task task;
-        switch (type) {
-            case T:
-                task = new ToDo(taskContent[2]);
-                break;
-            case D:
-                task = new Deadline(taskContent[2], taskContent[3]);
-                break;
-            case E:
-                task = new Event(taskContent[2], taskContent[3], taskContent[4]);
-                break;
-            default:
-                // corrupted data file case, i.e. content not in the expected format
-                // todo handle case where the content is not in the expected format
-                throw new DawnException("Invalid task type!");
-        }
-        if (isDone) {
-            task.markAsDone();
-        }
-        return task;
     }
 
     protected void clearSavedTask(String filePath) throws IOException {
@@ -111,28 +81,26 @@ public class Storage {
     }
 
     protected static void writeToFile(String filePath, Task task) throws IOException {
+        //todo change format to follow the actual input format from user so can reuse the addtask method
         FileWriter fw = new FileWriter(filePath, true);
-        String separator = " | ";
-        String isDone = task.isDone() ? "1" : "0";
+        String separator = "/";
+        String isDone = task.isDone() ? " 1 " : " 0 ";
         String desc = task.getDesc();
-        String deadline;
-        String from;
-        String to;
 
         String textToAdd;
 
         if (task instanceof ToDo) {
-            textToAdd = "T" + separator + isDone + separator + desc;
+            textToAdd = "TODO" + isDone + desc;
         } else if (task instanceof Deadline) {
             // We can safely typecast here since we already checked that task is an instance of Deadline
             Deadline t = (Deadline) task;
-            deadline = "by " + t.getDate() + " " + (t).getDeadline();
-            textToAdd = "D" + separator + isDone + separator + desc + separator + deadline;
+            String deadline = "by " + t.getDate() + " " + (t).getDeadline();
+            textToAdd = "DEADLINE" + isDone + desc + separator + deadline;
         } else { // task instanceof Event
             Event t = (Event) task;
-            from = "from " + t.getDate() + " " + t.getFromTime();
-            to = "to " + t.getToTime();
-            textToAdd = "E" + separator + isDone + separator + desc + separator + from + separator + to;
+            String from = "from " + t.getDate() + " " + t.getFromTime();
+            String to = "to " + t.getToTime();
+            textToAdd = "EVENT" + isDone + desc + separator + from + separator + to;
         }
         fw.write(textToAdd + System.lineSeparator());
         fw.close();

--- a/src/main/java/Dawn/TaskList.java
+++ b/src/main/java/Dawn/TaskList.java
@@ -13,15 +13,6 @@ public class TaskList {
         this.tasks = new ArrayList<>();
     }
 
-    /**
-     * Creates a new instance of a TaskList which contains the previously saved tasks
-     *
-     * @param savedTasks Previously saved tasks
-     */
-    public TaskList(ArrayList<Task> savedTasks) {
-        this.tasks = savedTasks;
-    }
-
     private enum Command {
         TODO,
         DEADLINE,
@@ -35,43 +26,48 @@ public class TaskList {
      * @param input Details of the tasks e.g. description, date, time etc
      * @throws DawnException
      */
-    public static String addTask(String command, String input) throws DawnException {
+    public static String addTask(String command, String input, String... optionalIsDoneStatus) throws DawnException {
         Command cmd = Command.valueOf(command);
         if (input.isBlank()) {
             throw new DawnException("You might be missing the task description, please check again\n");
         }
 
-        Task t = null;
-        String[] s = input.split("/");
+        Task t;
+        String[] details = input.split("/");
 
-        if (s[0].isBlank()) {
+        if (details[0].isBlank()) {
             throw new DawnException("You might be missing the task description, please check again\n");
         }
 
         switch (cmd) {
-            case TODO:
-                t = new ToDo(s[0]);
-                break;
-            case DEADLINE:
-                if (s.length < 2) {
-                    throw new DawnException("Make sure you include both the task description and the deadline in this" +
-                            " format:\n deadline [task name] /by [date yyyy-mm-dd] [time]\n" +
-                            "For example: deadline submit assignment1 /by 2024-09-16 2pm");
-                }
-                t = new Deadline(s[0], s[1]);
-                break;
-            case EVENT:
-                if (s.length < 3) {
-                    throw new DawnException("Make sure you include the task description, start, and end times for " +
-                            "your event in this format:\nevent [task name] /from [date yyyy-mm-dd] [time] / " +
-                            "to [time]\nFor example: event party /from 2024-09-01 5pm /to 9pm");
-                }
-                t = new Event(s[0], s[1], s[2]);
-                break;
+        case TODO:
+            t = new ToDo(details[0]);
+            break;
+        case DEADLINE:
+            if (details.length < 2) {
+                throw new DawnException("Make sure you include both the task description and the deadline in this" +
+                        " format:\n deadline [task name] /by [date yyyy-mm-dd] [time]\n" +
+                        "For example: deadline submit assignment1 /by 2024-09-16 2pm");
+            }
+            t = new Deadline(details[0], details[1]);
+            break;
+        case EVENT:
+            if (details.length < 3) {
+                throw new DawnException("Make sure you include the task description, start, and end times for " +
+                        "your event in this format:\nevent [task name] /from [date yyyy-mm-dd] [time] / " +
+                        "to [time]\nFor example: event party /from 2024-09-01 5pm /to 9pm");
+            }
+            t = new Event(details[0], details[1], details[2]);
+            break;
+        default:
+            return "I can't recognise the task, please only create tasks of type TODO, DEADLINE, or EVENT";
         }
         tasks.add(t);
+        if (optionalIsDoneStatus.length > 0 && optionalIsDoneStatus[0].equals("1")) {
+            t.markAsDone();
+        }
         return "Gotcha! I've added this task: \n" + tasks.size() + "." + t +
-                "\nNow you have " + tasks.size() + " task(s) in the list \n";
+                "\nNow you have " + tasks.size() + " task(details) in the list \n";
     }
 
     /**


### PR DESCRIPTION
There were two add tasks methods to handle the difference in format of the tasks that were stored from the previous use vs the tasks entered into the command line by the user.

Since these two methods have the same logic, let's merge them together so we don't have duplicate code.

Modifying the format in which tasks are stored so that they can be parsed easily, and modifying the way in which tasks are parsed to allow alternate formats.